### PR TITLE
feat: cli tool register install

### DIFF
--- a/src/extension.spec.ts
+++ b/src/extension.spec.ts
@@ -19,7 +19,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import * as podmanDesktopApi from '@podman-desktop/api';
-import { afterEach,beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { MinikubeDownload } from './download';
 import { activate, deactivate, refreshMinikubeClustersOnProviderConnectionUpdate } from './extension';


### PR DESCRIPTION
## Screenshots

1. minikube not installed

![image](https://github.com/user-attachments/assets/fcc7c41e-2a05-4e60-978e-c703a3c31499)

3. minikube installed

![image](https://github.com/user-attachments/assets/d9a31dda-fab5-4a89-84bf-4d9a89d50d47)

5. minikube update available

![image](https://github.com/user-attachments/assets/ef2da30d-e3fe-4b90-b2f2-3a81a2274d84)

## Related issues

Fixes https://github.com/containers/podman-desktop-extension-minikube/issues/149

## Testing

- [x] unit tests has been provided

1. go to CLITool
2. assert minikube cli tool card is visible
3. uninstall if already installed
4. assert no minikube provider in the resource page
5. install through cli tool page minikube
6. assert minikube provider in resource page